### PR TITLE
为首页文章列表设置缩略图

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -122,6 +122,8 @@ tags_title: Tags              #标签页
 categories_title: Categories  #分类页
 archives_title: Archives      #归档页
 
+# 是否开启文章缩略图，开启请填写图片外链，为了测试这里提供了一张40kb大小的图片，任何尺寸都能保证画质
+defaultthumb: false #https://i.loli.net/2017/12/12/5a2fd18a74471.jpg
 # 自动生成文章摘要
 ## 显示在主页中
 ## excerpt_length只在excerpt_render为true时生效。

--- a/layout/_partial/index-item.ejs
+++ b/layout/_partial/index-item.ejs
@@ -12,6 +12,14 @@
         <%- partial('post/repo-icon') %>
         <%- partial('post/music') %>
     </div>
+    
+    <% if (theme.defaultthumb && !post.src) { %>
+        <%- partial('post/thumb',{src: theme.defaultthumb}) %>
+        <% } %>
+    <% if (post.src) { %>
+        <%- partial('post/thumb',{src:post.src }) %>
+        <% } %>
+    
     <div class="post-content" id="post-content" itemprop="postContent">
     <%
         // 首页缩略图大小及路径处理

--- a/layout/_partial/post/thumb.ejs
+++ b/layout/_partial/post/thumb.ejs
@@ -1,0 +1,1 @@
+<img src="<%= src %>"  id="thumb" alt="">

--- a/source/css/_partial/postlist.less
+++ b/source/css/_partial/postlist.less
@@ -110,7 +110,28 @@
         box-shadow: 0 2px 4px saturate(@textPrimaryColorBlack, .3);
     }
 }
-
+#thumb{
+    display: block;
+    width: 100%;
+    border: none;
+    margin-bottom: 8px;
+    // height: 400px;
+    // @media screen and (max-width:1440px) {
+    //     height: 26%;
+    // }
+    // @media screen and (max-width:1080px) {
+    //     height: 30%;
+    // }
+    @media screen and (max-width:1440px) {
+        height: 400px;
+    }
+    @media screen and (max-width:720px) {
+        height: 280px;
+    }
+    @media screen and (max-width:500px) {
+        height: 200px;
+    }
+}
 .post-more {
     width: 50px;
     margin: 10px auto 0;


### PR DESCRIPTION

> 可以在主题配置下设置是否开启显示默认缩略图,默认false不开启，开启请设置url，懒癌患者可直接启用后面给定的图片，若要添加每篇文章的缩略图，可以在头部设置src: url，格式为外链，也最好为外链，图片的尺寸1080*400左右为宜